### PR TITLE
use test roles when running locally

### DIFF
--- a/src/main/scala/no/ndla/network/jwt/JWTExtractor.scala
+++ b/src/main/scala/no/ndla/network/jwt/JWTExtractor.scala
@@ -32,7 +32,10 @@ class JWTExtractor(request: HttpServletRequest) {
 
   def extractUserRoles(): List[String] = {
     val rawRoles = jwtClaims.map(_.scope).getOrElse(List.empty)
-    val env = Properties.envOrElse("NDLA_ENVIRONMENT", "local")
+    val env = Properties.envOrElse("NDLA_ENVIRONMENT", "local") match {
+      case "local" => "test"
+      case x => x
+    }
     val envSuffix = s"-$env:"
     val roles = rawRoles.filter(_.contains(envSuffix)).map(_.replace(envSuffix, ":"))
     // Legacy-support. Don't remove roles without env-suffix. May be deleted when all clients are migrated to auth0 and the auth component is deleted


### PR DESCRIPTION
Litt usikker på om det er dette som er den beste måten å gjøre det på. Dersom en komponent kjører lokalt vil dette bety at rollene for test blir brukt. Det andre alternativet er kanskje å lage egne roller for local, men føler kanskje det blir litt feil.
Et tredje alternativ er å kode network slik at roller ikke gjelder i det hele tatt når man kjører lokalt