### PR TITLE
#914: Adds implicit formats parameter to functions that use parseResponse

### DIFF
--- a/src/main/scala/no/ndla/network/NdlaClient.scala
+++ b/src/main/scala/no/ndla/network/NdlaClient.scala
@@ -10,6 +10,7 @@ package no.ndla.network
 
 import com.typesafe.scalalogging.LazyLogging
 import no.ndla.network.model.HttpRequestException
+import org.json4s.Formats
 import org.json4s.jackson.JsonMethods._
 
 import scala.util.{Failure, Success, Try}
@@ -19,30 +20,29 @@ trait NdlaClient {
   val ndlaClient: NdlaClient
 
   class NdlaClient extends LazyLogging {
-    implicit val formats = org.json4s.DefaultFormats
-
+    implicit val formats: Formats = org.json4s.DefaultFormats
 
     def fetch[A](request: HttpRequest)(implicit mf: Manifest[A]): Try[A] = {
       doFetch(
         addCorrelationId(request))
     }
 
-    def fetchWithBasicAuth[A](request: HttpRequest, user: String, password: String)(implicit mf: Manifest[A]): Try[A] = {
+    def fetchWithBasicAuth[A](request: HttpRequest, user: String, password: String)(implicit mf: Manifest[A], formats: Formats): Try[A] = {
       doFetch(
         addCorrelationId(
           addBasicAuth(request, user, password)))
     }
 
-    def fetchWithForwardedAuth[A](request: HttpRequest)(implicit mf: Manifest[A]): Try[A] = {
+    def fetchWithForwardedAuth[A](request: HttpRequest)(implicit mf: Manifest[A], formats: Formats = formats): Try[A] = {
       doFetch(
         addCorrelationId(
           addForwardedAuth(request)))
     }
 
-    private def doFetch[A](request: HttpRequest)(implicit mf: Manifest[A]): Try[A] = {
+    private def doFetch[A](request: HttpRequest)(implicit mf: Manifest[A], formats: Formats = formats): Try[A] = {
       for {
         httpResponse <- doRequest(request)
-        bodyObject <- parseResponse[A](httpResponse)(mf)
+        bodyObject <- parseResponse[A](httpResponse)(mf, formats)
       } yield bodyObject
     }
 
@@ -57,7 +57,7 @@ trait NdlaClient {
       })
     }
 
-    private def parseResponse[A](response: HttpResponse[String])(implicit mf: Manifest[A]): Try[A] = {
+    private def parseResponse[A](response: HttpResponse[String])(implicit mf: Manifest[A], formats: Formats = formats): Try[A] = {
       Try(parse(response.body).camelizeKeys.extract[A]) match {
         case Success(extracted) => Success(extracted)
         case Failure(ex) => {

--- a/src/main/scala/no/ndla/network/NdlaClient.scala
+++ b/src/main/scala/no/ndla/network/NdlaClient.scala
@@ -27,7 +27,7 @@ trait NdlaClient {
         addCorrelationId(request))
     }
 
-    def fetchWithBasicAuth[A](request: HttpRequest, user: String, password: String)(implicit mf: Manifest[A], formats: Formats): Try[A] = {
+    def fetchWithBasicAuth[A](request: HttpRequest, user: String, password: String)(implicit mf: Manifest[A], formats: Formats = formats): Try[A] = {
       doFetch(
         addCorrelationId(
           addBasicAuth(request, user, password)))

--- a/src/test/scala/no/ndla/network/NdlaClientTest.scala
+++ b/src/test/scala/no/ndla/network/NdlaClientTest.scala
@@ -9,7 +9,6 @@
 package no.ndla.network
 
 import javax.servlet.http.HttpServletRequest
-import org.json4s.Formats
 import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.TryValues._
@@ -101,8 +100,6 @@ class NdlaClientTest extends UnitSuite with NdlaClient {
   }
 
   test("That BasicAuth header is added to request when user and password is defined") {
-    implicit val formats: Formats = org.json4s.DefaultFormats
-
     val user = "user"
     val password = "password"
 

--- a/src/test/scala/no/ndla/network/NdlaClientTest.scala
+++ b/src/test/scala/no/ndla/network/NdlaClientTest.scala
@@ -9,11 +9,10 @@
 package no.ndla.network
 
 import javax.servlet.http.HttpServletRequest
-
+import org.json4s.Formats
 import org.mockito.Matchers.{eq => eqTo, _}
 import org.mockito.Mockito._
 import org.scalatest.TryValues._
-
 import scalaj.http.{HttpRequest, HttpResponse}
 
 class NdlaClientTest extends UnitSuite with NdlaClient {
@@ -102,6 +101,8 @@ class NdlaClientTest extends UnitSuite with NdlaClient {
   }
 
   test("That BasicAuth header is added to request when user and password is defined") {
+    implicit val formats: Formats = org.json4s.DefaultFormats
+
     val user = "user"
     val password = "password"
 


### PR DESCRIPTION
Needed in cases where `NdlaClient.parseResponse` parses classes with a custom serializer.