### PR TITLE
Downgrade jwt-json4s-native for compability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,8 @@ lazy val network = (project in file("."))
       "org.mockito" % "mockito-core" % MockitoVersion % "test",
       "javax.servlet" % "javax.servlet-api" % "4.0.1" % "provided;test",
       "com.amazonaws" % "aws-java-sdk-s3" % AwsSdkversion,
-      "com.pauldijou" %% "jwt-json4s-native" % "0.19.0"
+      "com.pauldijou" %% "jwt-json4s-native" % "0.15.0",
+      "org.bouncycastle" % "bcprov-jdk15on" % "1.60" // Overriding bouncycastle used in jwt-json4s-native: https://app.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-32412
     )
   )
 


### PR DESCRIPTION
Viser seg at `jwt-json4s-native` > `0.15` bruker json4s `3.6.0` som kræsjer med scalatra som fortsatt bruker `3.5.x`