### PR TITLE
Improved error message (and cause exception) when parsing body

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,6 @@ jobs:
       - uses: olafurpg/setup-scala@v10
         with:
           java-version: adopt@1.11
-      - name: "Install awscli"
-        run: |
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-          unzip awscliv2.zip
-          sudo ./aws/install
       - name: "Login to ECR repo"
         run: RES=$(aws sts assume-role --role-arn arn:aws:iam::950645517739:role/releaseAccess --role-session-name travis-test-release-pull-whatever)
           AWS_ACCESS_KEY_ID=$(echo $RES | jq -r .Credentials.AccessKeyId)

--- a/src/main/scala/no/ndla/network/NdlaClient.scala
+++ b/src/main/scala/no/ndla/network/NdlaClient.scala
@@ -55,8 +55,7 @@ trait NdlaClient {
           case true => {
             Failure(new HttpRequestException(
               s"Received error ${response.code} ${response.statusLine} when calling ${request.url}. Body was ${response.body}",
-              Some(response),
-              None
+              Some(response)
             ))
           }
         }

--- a/src/main/scala/no/ndla/network/NdlaClient.scala
+++ b/src/main/scala/no/ndla/network/NdlaClient.scala
@@ -19,6 +19,7 @@ trait NdlaClient {
 
   class NdlaClient {
     implicit val formats: Formats = org.json4s.DefaultFormats
+    private val ResponseErrorBodyCharacterCutoff = 1000
 
     def fetch[A](request: HttpRequest)(implicit mf: Manifest[A]): Try[A] = {
       doFetch(addCorrelationId(request))
@@ -54,7 +55,9 @@ trait NdlaClient {
           case true => {
             Failure(new HttpRequestException(
               s"Received error ${response.code} ${response.statusLine} when calling ${request.url}. Body was ${response.body}",
-              Some(response)))
+              Some(response),
+              None
+            ))
           }
         }
       })
@@ -64,8 +67,16 @@ trait NdlaClient {
                                                                  formats: Formats = formats): Try[A] = {
       Try(parse(response.body).camelizeKeys.extract[A]) match {
         case Success(extracted) => Success(extracted)
-        case Failure(ex) =>
-          Failure(new HttpRequestException(s"Could not parse response ${response.body}", Some(response)))
+        case Failure(ex)        =>
+          // Large bodies in the error message can be very noisy.
+          // If they are actually needed the `httpResponse` field of the exception can be used
+          val errBody =
+            if (response.body.length > ResponseErrorBodyCharacterCutoff)
+              s"'${response.body.substring(0, 1000)}'... (Cut off)"
+            else response.body
+
+          val newEx = new HttpRequestException(s"Could not parse response with body: $errBody", Some(response))
+          Failure(newEx.initCause(ex))
       }
     }
 

--- a/src/main/scala/no/ndla/network/model/HttpRequestException.scala
+++ b/src/main/scala/no/ndla/network/model/HttpRequestException.scala
@@ -10,7 +10,7 @@ package no.ndla.network.model
 
 import scalaj.http.HttpResponse
 
-class HttpRequestException(message: String, val httpResponse: Option[HttpResponse[String]] = None)
+class HttpRequestException(message: String, httpResponse: Option[HttpResponse[String]] = None)
     extends RuntimeException(message) {
   def is404: Boolean = httpResponse.exists(_.isCodeInRange(404, 404))
 }

--- a/src/test/scala/no/ndla/network/NdlaClientTest.scala
+++ b/src/test/scala/no/ndla/network/NdlaClientTest.scala
@@ -62,7 +62,7 @@ class NdlaClientTest extends UnitSuite with NdlaClient {
 
     val result = ndlaClient.fetch[TestObject](httpRequestMock)
     result.isFailure should be(true)
-    result.failure.exception.getMessage should equal(s"Could not parse response $unparseableResponse")
+    result.failure.exception.getMessage should equal(s"Could not parse response with body: $unparseableResponse")
   }
 
   test("That a testObject is returned when no error is returned and content is parseable") {


### PR DESCRIPTION
- Printer max 1000 characters av en feilet body
- Legger til cause exception slik at man får en bittelitt bedre indikator på hva som er galt med json4s exceptions